### PR TITLE
Add .treeinfo for Leap Micro 6.0 and Leap 16.0

### DIFF
--- a/skelcd/.treeinfo.1600
+++ b/skelcd/.treeinfo.1600
@@ -1,0 +1,21 @@
+[header]
+version = 1.0
+
+[release]
+name = openSUSE Leap
+version = 16.0
+
+[general]
+arch = x86_64
+family = openSUSE Leap
+name = openSUSE Leap 16.0
+version = 16.0
+platforms = x86_64,xen
+
+[images-x86_64]
+kernel = boot/x86_64/loader/linux
+initrd = boot/x86_64/loader/initrd
+
+[images-xen]
+kernel = boot/x86_64/loader/linux
+initrd = boot/x86_64/loader/initrd


### PR DESCRIPTION
Fixes build of https://build.opensuse.org/package/show/openSUSE:Leap:Micro:6.0/skelcd-openSUSE


`[   13s] + cp skelcd/.treeinfo.1600 /home/abuild/rpmbuild/BUILDROOT/skelcd-openSUSE-84.87.20220225.f4ee64a-4.1.x86_64/usr/lib/skelcd/CD1/.treeinfo`
`[   13s] cp: cannot stat 'skelcd/.treeinfo.1600': No such file or directory`